### PR TITLE
Add icon theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kshift - KDE Theme Shift
 
- kshift is a KDE theme shifting script that activates at set times to switch themes, including sunrise and sunset. When run manually, it sets the color theme and/or wallpaper to the 'correct' value based on current time. It uses `plasma-apply-colorscheme` for color themes, `plasma-apply-wallpaperimage` for wallpapers, and python `os.system()` for commands.
+ kshift is a KDE theme shifting script that activates at set times to switch themes, including sunrise and sunset. When run manually, it sets the color theme and/or wallpaper to the 'correct' value based on current time. It uses `plasma-apply-colorscheme` for color themes, `plasma-changeicons` for icon themes, `plasma-apply-wallpaperimage` for wallpapers, and python `os.system()` for commands.
 
  During installation, kshift sets systemd timers to run the script at any time a theme is set, including sunrise/sunset.
  The sunrise and sunset times are updated when kshift is ran.
@@ -14,7 +14,7 @@ https://github.com/justjokiing/kshift/assets/64444712/02e64459-5f5b-477b-a0aa-bd
 
 ## Usage
 
-    usage: kshift [-h] [-w WALLPAPER] [-c COLORSCHEME] [-t {day,night}] [--install | --remove | -s]
+    usage: kshift [-h] [-w WALLPAPER] [-c COLORSCHEME] [-i ICONTHEME] [-t {day,night}] [--install | --remove | -s]
 
     KDE Theme Switching
 
@@ -24,6 +24,8 @@ https://github.com/justjokiing/kshift/assets/64444712/02e64459-5f5b-477b-a0aa-bd
                             Sets the current wallpaper
       -c COLORSCHEME, --colorscheme COLORSCHEME
                             Sets the colorscheme
+      -i ICONTHEME, --icontheme ICONTHEME
+                            Sets the icon theme
       -t {day,night}, --theme {day,night}
                             Sets the theme
       --install             Installs Kshift
@@ -56,16 +58,18 @@ https://github.com/justjokiing/kshift/assets/64444712/02e64459-5f5b-477b-a0aa-bd
     themes:
       day:
         colorscheme: BreezeLight  # Check 'plasma-apply-colorscheme -l' for options
+        icontheme: breeze
         wallpaper: /usr/share/wallpapers/Flow/contents/images/5120x2880.jpg
         command: ''               # Runs command at theme activation
         time: sunrise             # Keywords 'sunrise', 'sunset', or time in 'HH:MM' format
       night:
         colorscheme: BreezeDark
+        icontheme: breeze-dark
         wallpaper: /usr/share/wallpapers/Flow/contents/images_dark/5120x2880.jpg
         command: ''
         time: sunset
    ```
-	The themes default are set to a set of default day and night KDE themes and wallpapers. You can add as many themes as you would like at many different times, wallpapers, commands, and colorschemes. None of the theme variables are required. If time is not set, there will be no automatic transition.
+	The themes default are set to a set of default day and night KDE themes and wallpapers. You can add as many themes as you would like at many different times, wallpapers, commands, icons, and colorschemes. None of the theme variables are required. If time is not set, there will be no automatic transition.
     
     The time variables "sunrise" and "sunset" are keywords to kshift and are replaced with the sunrise and sunset times that your location variable sets. __Make sure to use correct YAML syntax.__
 

--- a/src/defaults.yml
+++ b/src/defaults.yml
@@ -8,13 +8,15 @@ net_timeout: 10    # How long to wait for network timeout
 themes:
   day:
     colorscheme: BreezeLight  # Check 'plasma-apply-colorscheme -l' for options
+    icontheme: breeze
     wallpaper: /usr/share/wallpapers/Flow/contents/images/5120x2880.jpg
     command: ''               # Runs command at theme activation
-    time: 
+    time:
       - sunrise             # Keywords 'sunrise', 'sunset', or time in 'HH:MM' format
   night:
     colorscheme: BreezeDark
+    icontheme: breeze-dark
     wallpaper: /usr/share/wallpapers/Flow/contents/images_dark/5120x2880.jpg
     command: ''
-    time: 
+    time:
       - sunset

--- a/src/kshift
+++ b/src/kshift
@@ -10,7 +10,7 @@ import theme
 themes = []
 themes_dic = {}
 
-c = conf.config();
+c = conf.config()
 
 # This loop goes through the data from the yaml file
 # it iterates over the attributes for theme, currently colorscheme, wallpaper, and color
@@ -28,7 +28,7 @@ for name in c.data["themes"]:
         time = [time]
 
     for ti in time:
-        t = theme.Theme(name, colorscheme, wallpaper, command, ti ) 
+        t = theme.Theme(name, colorscheme, wallpaper, command, ti )
 
         themes_dic[name] = t
         themes.append(t)
@@ -67,7 +67,7 @@ def write_timer():
 # Copies executable, creates config file, utilizes the write timer func, and enables the timer
 def install():
 
-    exec_name = os.path.basename(__file__) 
+    exec_name = os.path.basename(__file__)
 
     kshift_service="[Unit]\nDescription=kshift service\n\n[Service]\nExecStart="+c.home+"/.local/bin/"+exec_name
 
@@ -124,7 +124,7 @@ parser.add_argument("-c","--colorscheme", type=str,help="Sets the colorscheme", 
 parser.add_argument("-t", "--theme", help="Sets the theme", type=str, choices=list(c.data["themes"].keys()), required=False)
 
 
-# These cannot be called together 
+# These cannot be called together
 install_g = parser.add_mutually_exclusive_group(required=False)
 install_g.add_argument("--install", help="Installs Kshift", action="store_true")
 install_g.add_argument("--remove", help="Removes Kshift", action="store_true")
@@ -165,14 +165,13 @@ else:
         # if none is greater, then do nothing.
         for theme in themes:
 
-            if theme.time == None:
+            if theme.time is None:
                 break
             elif c.today >= theme.time:
                 theme_to_be = theme
                 break
-   
+
         if theme_to_be:
             theme_to_be.kshift()
 
     write_timer()
-

--- a/src/kshift
+++ b/src/kshift
@@ -28,7 +28,7 @@ for name in c.data["themes"]:
         time = [time]
 
     for ti in time:
-        t = theme.Theme(name, colorscheme, wallpaper, command, ti )
+        t = theme.Theme(name, colorscheme, icontheme, wallpaper, command, ti )
 
         themes_dic[name] = t
         themes.append(t)
@@ -121,6 +121,7 @@ parser = argparse.ArgumentParser(description="KDE Theme Switching")
 
 parser.add_argument("-w", "--wallpaper", help="Sets the current wallpaper", type=str, required=False)
 parser.add_argument("-c","--colorscheme", type=str,help="Sets the colorscheme", required=False)
+parser.add_argument("-i","--icontheme", type=str,help="Sets the icon theme", required=False)
 parser.add_argument("-t", "--theme", help="Sets the theme", type=str, choices=list(c.data["themes"].keys()), required=False)
 
 
@@ -154,8 +155,8 @@ else:
     if args.theme:
         themes_dic[args.theme].kshift()
 
-    elif args.colorscheme or args.wallpaper:
-        theme.Theme("tmp", args.colorscheme, args.wallpaper, None, None).kshift()
+    elif args.colorscheme or args.icontheme or args.wallpaper:
+        theme.Theme("tmp", args.colorscheme, args.icontheme, args.wallpaper, None, None).kshift()
 
     else:
 

--- a/src/theme.py
+++ b/src/theme.py
@@ -12,11 +12,12 @@ c = conf.config()
 
 @total_ordering
 class Theme:
-    attributes = ["colorscheme", "wallpaper", "command", "time"]
+    attributes = ["colorscheme", "icontheme", "wallpaper", "command", "time"]
 
     colorschemes = utils.get_colorschemes()
+    iconthemes = utils.get_iconthemes()
 
-    def __init__(self, name, colorscheme, wallpaper, command, time):
+    def __init__(self, name, colorscheme, icontheme, wallpaper, command, time):
         self.name = name
 
         if colorscheme is None or self.colorschemes.count(colorscheme) >= 1:
@@ -24,6 +25,10 @@ class Theme:
         else:
             raise ValueError("Unknown colorscheme: "+colorscheme)
 
+        if icontheme is None or self.iconthemes.count(icontheme) >= 1:
+            self.icontheme = icontheme
+        else:
+            raise ValueError("Unknown icon theme: "+icontheme)
 
         if wallpaper is None or os.path.exists(wallpaper):
             self.wallpaper = wallpaper
@@ -61,7 +66,7 @@ class Theme:
             return False
 
     def __repr__(self) -> str:
-        return "Name: {}, ColorScheme: {}, Wallpaper: {}, Time: {}\n".format(self.name,self.colorscheme,self.wallpaper,self.time)
+        return "Name: {}, ColorScheme: {}, IconTheme: {}, Wallpaper: {}, Time: {}\n".format(self.name,self.colorscheme,self.icontheme,self.wallpaper,self.time)
 
 
     ###################################
@@ -78,6 +83,11 @@ class Theme:
 
         if self.colorscheme and self.colorscheme != utils.curr_colorscheme():
             os.system("plasma-apply-colorscheme "+ self.colorscheme)
+
+        if self.icontheme and self.icontheme != utils.curr_icontheme():
+            plasma_changeicons = utils.find_plasma_changeicons()
+            if (plasma_changeicons is not None):
+                os.system(plasma_changeicons + " " + self.icontheme)
 
         if self.command:
             os.system(self.command)

--- a/src/theme.py
+++ b/src/theme.py
@@ -6,7 +6,7 @@ from functools import total_ordering
 import conf
 import utils
 
-c = conf.config();
+c = conf.config()
 
 # Class used for holding a theme data, and sorting these themes
 
@@ -19,13 +19,13 @@ class Theme:
     def __init__(self, name, colorscheme, wallpaper, command, time):
         self.name = name
 
-        if colorscheme == None or self.colorschemes.count(colorscheme) >= 1:
+        if colorscheme is None or self.colorschemes.count(colorscheme) >= 1:
             self.colorscheme = colorscheme
         else:
             raise ValueError("Unknown colorscheme: "+colorscheme)
 
 
-        if wallpaper == None or os.path.exists(wallpaper):
+        if wallpaper is None or os.path.exists(wallpaper):
             self.wallpaper = wallpaper
         else:
             raise ValueError("Wallpaper does not exist: "+wallpaper)
@@ -39,7 +39,7 @@ class Theme:
             else:
                 tmp_time = datetime.datetime.strptime(c.data[time], "%H:%M")
                 self.time = c.delay_time(c.today.replace(hour=tmp_time.hour, minute=tmp_time.minute), time)
-        elif time == None:
+        elif time is None:
             self.time = None
         else:
             tmp_time = datetime.datetime.strptime(time, "%H:%M")
@@ -49,13 +49,13 @@ class Theme:
         return isinstance(__o,Theme) and self.time == __o.time
 
     def __ge__(self, __o) -> bool:
-        if isinstance(__o,Theme) and __o.time != None and self.time != None:
+        if isinstance(__o,Theme) and __o.time is not None and self.time is not None:
             return self.time > __o.time
         else:
             return False
 
     def __le__(self, __o) -> bool:
-        if isinstance(__o,Theme) and __o.time != None and self.time != None:
+        if isinstance(__o,Theme) and __o.time is not None and self.time is not None:
             return self.time < __o.time
         else:
             return False
@@ -81,4 +81,3 @@ class Theme:
 
         if self.command:
             os.system(self.command)
-

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,7 +10,7 @@ def get_colorschemes():
     output = subprocess.run(colorscheme_cmd.split(), stdout=subprocess.PIPE).stdout.decode('utf-8').strip()
 
     for line in output.splitlines():
-        r = re.search(" \* ([A-Za-z]*)", line)
+        r = re.search(" \\* ([A-Za-z]*)", line)
         if r:
             arr.append(r.group(1))
 
@@ -25,7 +25,7 @@ def curr_colorscheme():
     output = subprocess.run(colorscheme_cmd.split(), stdout=subprocess.PIPE).stdout.decode('utf-8').strip()
 
     for line in output.splitlines():
-        r = re.search(" \* ([A-Za-z]*) \(current color scheme\)", line)
+        r = re.search(" \\* ([A-Za-z]*) \\(current color scheme\\)", line)
         if r:
             curr = r.group(1)
             break

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,7 @@
 import subprocess
 import re
+import os
+import configparser
 
 # Gets the names of all available colorschemes
 def get_colorschemes():
@@ -31,3 +33,51 @@ def curr_colorscheme():
             break
 
     return curr
+
+def get_iconthemes():
+
+    arr = []
+
+    home_dir = os.path.expanduser("~")
+    old_icon_dir = home_dir + "/.icons"
+    icon_dir = home_dir + "/.local/share/icons"
+    system_icon_dir = "/usr/share/icons"
+
+    for path in [old_icon_dir, icon_dir, system_icon_dir]:
+        if os.path.exists(path):
+            output = subprocess.run(["ls", path], stdout=subprocess.PIPE).stdout.decode('utf-8').strip()
+            arr += output.split()
+
+    return arr
+
+# Gets the current icon theme
+def curr_icontheme():
+
+    curr = ""
+    kdeconfig_path = os.path.expanduser("~") + "/.config/kdeglobals"
+
+    if os.path.exists(kdeconfig_path):
+        config = configparser.ConfigParser()
+        config.read(kdeconfig_path)
+        curr = config["Icons"]["Theme"]
+
+    return curr
+
+
+# Gets the path to plasma-changeicon
+def find_plasma_changeicons():
+    search_paths = [
+        "/usr/local/libexec",
+        "/usr/local/lib",
+        "/usr/libexec",
+        "/usr/lib",
+        "/usr/lib/x86_64-linux-gnu/libexec",
+        "/usr/lib/aarch64-linux-gnu/libexec"
+    ]
+
+    for path in search_paths:
+        executable_path = os.path.join(path, "plasma-changeicons")
+        if os.path.isfile(executable_path):
+            return executable_path
+
+    return None


### PR DESCRIPTION
Currently kshift does not change the icon theme when changing the color scheme. When used with the breeze/breeze-dark icon theme this can cause light icon on light background  or dark icon on dark background in some applications. 
Unfortunately there is no plasma-apply-icontheme for the moment, so in this commit we:
- look at the installed icon themes in known standard path
- get the current icon theme from kdeglobals
- and try to find plasma-changeicons, which is unfortunately in libexec, so not in path and not guaranteed to be there (notably on debian and ubuntu, so I included their path)

I also fixed some common python linter warnings (using is for none comparison and useless `;`) and the regular expression which failed with `SyntaxWarning: invalid escape sequence '\*'` on my system.

Happy new year :confetti_ball: !